### PR TITLE
Fix invitation access validation: use guest_email instead of user field

### DIFF
--- a/backend/networking/html_views.py
+++ b/backend/networking/html_views.py
@@ -92,9 +92,14 @@ def validate_event_access(user: User, event: Event) -> tuple[bool, str]:
     """
     try:
         from invitations.models import Invitation
-        invitation = Invitation.objects.get(user=user, event=event)
-        if invitation.status not in ['accepted', 'attended']:
-            return False, "You don't have access to this event's networking features"
+        # Find invitation by matching guest_email with user's email
+        invitation = Invitation.objects.get(guest_email=user.email, event=event)
+        
+        # Check RSVP status (PENDING, ATTENDING, DECLINED)
+        if invitation.rsvp_status == 'DECLINED':
+            return False, "You have declined this event invitation"
+        
+        # Allow PENDING and ATTENDING users to access networking features
         return True, ""
     except Invitation.DoesNotExist:
         return False, "You must be invited to this event to view networking features"


### PR DESCRIPTION
Fixed critical error in validate_event_access() function:
- Changed from non-existent 'user' field to 'guest_email' field
- Properly matches invitation to user via email address
- Updated RSVP status validation to use correct field values
- Allows PENDING and ATTENDING users to access networking features
- Blocks DECLINED invitations appropriately

This resolves the "Cannot resolve keyword 'user' into field" error that was preventing the connections page from loading.